### PR TITLE
Use public API in `derive_circuit` only

### DIFF
--- a/qiskit_algorithms/gradients/reverse/reverse_gradient.py
+++ b/qiskit_algorithms/gradients/reverse/reverse_gradient.py
@@ -144,7 +144,8 @@ class ReverseEstimatorGradient(BaseEstimatorGradient):
                 parameter_j = paramlist[j][0]
 
                 # get the analytic gradient d U_j / d p_j and bind the gate
-                deriv = derive_circuit(unitary_j, parameter_j)
+                # we skip the check since we know the circuit has unique, valid parameters
+                deriv = derive_circuit(unitary_j, parameter_j, check=False)
                 for _, gate in deriv:
                     bind(gate, parameter_binds, inplace=True)
 

--- a/qiskit_algorithms/gradients/reverse/reverse_qgt.py
+++ b/qiskit_algorithms/gradients/reverse/reverse_qgt.py
@@ -131,7 +131,8 @@ class ReverseQGT(BaseQGT):
             # Note: We currently only support gates with a single parameter -- which is reflected
             # in self.SUPPORTED_GATES -- but generally we could also support gates with multiple
             # parameters per gate. This is the reason for the second 0-index.
-            deriv = derive_circuit(unitaries[0], paramlist[0][0])
+            # We skip the check since we know the circuit has unique, valid parameters.
+            deriv = derive_circuit(unitaries[0], paramlist[0][0], check=False)
             for _, gate in deriv:
                 bind(gate, parameter_binds, inplace=True)
 
@@ -149,7 +150,7 @@ class ReverseQGT(BaseQGT):
                 phi = psi.copy()
 
                 # get the analytic gradient d U_j / d p_j and apply it
-                deriv = derive_circuit(unitaries[j], paramlist[j][0])
+                deriv = derive_circuit(unitaries[j], paramlist[j][0], check=False)
 
                 for _, gate in deriv:
                     bind(gate, parameter_binds, inplace=True)
@@ -170,7 +171,7 @@ class ReverseQGT(BaseQGT):
                     lam = lam.evolve(bound_unitaries[i].inverse())
 
                     # get the gradient d U_i / d p_i and apply it
-                    deriv = derive_circuit(unitaries[i], paramlist[i][0])
+                    deriv = derive_circuit(unitaries[i], paramlist[i][0], check=False)
                     for _, gate in deriv:
                         bind(gate, parameter_binds, inplace=True)
 

--- a/qiskit_algorithms/gradients/utils.py
+++ b/qiskit_algorithms/gradients/utils.py
@@ -137,13 +137,6 @@ def _make_lin_comb_gradient_circuit(
                 lin_comb_circuit.h(qr_aux)
                 if add_measurement:
                     lin_comb_circuit.measure(qr_aux, cr_aux)
-                # This next line which assigns data is a workaround otherwise the
-                # circuit parameters may not be properly recognized as data is now
-                # managed in Rust and changing things may break parameters - making a
-                # copy of itself by assignment sorts things out.
-                # See https://github.com/Qiskit/qiskit/blob/main/releasenotes/notes
-                #     /circuit-gates-rust-5c6ab6c58f7fd2c9.yaml#L47-L79
-                lin_comb_circuit.data = lin_comb_circuit.data
                 lin_comb_circuits[p] = lin_comb_circuit
 
     return lin_comb_circuits


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ Also, please add it in the CHANGELOG file under Unreleased section.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

https://github.com/Qiskit/qiskit/pull/12794 fixes the faulty behavior requiring the copy of `circuit.data`, but breaks other parts of the gradients that use the private `_parameter_table`. This PR uses only public API function to avoid breaking in this way in the future.

